### PR TITLE
chore(bus): initial impl of message bus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/allinbits/magic-message-bus
 
 go 1.15
 
+replace github.com/cosmos/cosmos-sdk => /home/ghost/git/PaddyMc/cosmos-sdk
+
 require (
 	github.com/cosmos/cosmos-sdk v0.40.0-rc3
 	github.com/gogo/protobuf v1.3.1
@@ -15,6 +17,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/tendermint/tendermint v0.34.0-rc6
 	github.com/tendermint/tm-db v0.6.2
+	github.com/vardius/message-bus v1.1.5
 	google.golang.org/genproto v0.0.0-20201014134559-03b6142f0dc9
 	google.golang.org/grpc v1.33.0
 

--- a/go.sum
+++ b/go.sum
@@ -104,8 +104,6 @@ github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/cosmos/cosmos-sdk v0.40.0-rc3 h1:sS9BZ82dOxXiZPZdfrzSniEAzLLN0oTP5lFVyjnq2x4=
-github.com/cosmos/cosmos-sdk v0.40.0-rc3/go.mod h1:eKgbkQO4FEvC+a1+eyRuL7UgluGK1ad4PufPTpQc6ZA=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d h1:49RLWk1j44Xu4fjHb6JFYmeUnDORVwHNkDxaQ0ctCVU=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cosmos/iavl v0.15.0-rc3.0.20201009144442-230e9bdf52cd/go.mod h1:3xOIaNNX19p0QrX0VqWa6voPRoJRGGYtny+DH8NEPvE=
@@ -591,6 +589,8 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/vardius/message-bus v1.1.5 h1:YSAC2WB4HRlwc4neFPTmT88kzzoiQ+9WRRbej/E/LZc=
+github.com/vardius/message-bus v1.1.5/go.mod h1:6xladCV2lMkUAE4bzzS85qKOiB5miV7aBVRafiTJGqw=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/zondax/hid v0.9.0 h1:eiT3P6vNxAEVxXMw66eZUAAnU2zD33JBkfG/EnfAKl8=

--- a/readme.md
+++ b/readme.md
@@ -1,31 +1,15 @@
 # magicmessagebus
 
-**magicmessagebus** is a blockchain application built using Cosmos SDK and Tendermint and generated with [Starport](https://github.com/tendermint/starport).
+sample application to use a message bus for module communication in the cosmos-sdk
 
-## Get started
+code in this POC removes the need to pass keepers into other keeper's constructors
 
-```
-starport serve
-```
+# how to test
 
-`serve` command installs dependencies, initializes and runs the application.
+- startport serve
 
-## Configure
+in another terminal
 
-Initialization parameters of your app are stored in `config.yml`.
-
-### `accounts`
-
-A list of user accounts created during genesis of your application.
-
-| Key   | Required | Type            | Description                                       |
-| ----- | -------- | --------------- | ------------------------------------------------- |
-| name  | Y        | String          | Local name of the key pair                        |
-| coins | Y        | List of Strings | Initial coins with denominations (e.g. "100coin") |
-
-## Learn more
-
-- [Starport](https://github.com/tendermint/starport)
-- [Cosmos SDK documentation](https://docs.cosmos.network)
-- [Cosmos Tutorials](https://tutorials.cosmos.network)
-- [Channel on Discord](https://discord.gg/W8trcGV)
+- cd /cmd/magic-message-bus
+- go run main.go tx magicmessagebus create-poll bus asd --from user1 --keyring-backend test --chain-id magicmessagebus
+- go run main.go query bank balances cosmos1xm82mkw2jkwkdgq3r0cu8f92r9t2emm8m8xpuw

--- a/x/magicmessagebus/handler_poll.go
+++ b/x/magicmessagebus/handler_poll.go
@@ -4,6 +4,7 @@ import (
 	"github.com/allinbits/magic-message-bus/x/magicmessagebus/keeper"
 	"github.com/allinbits/magic-message-bus/x/magicmessagebus/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/google/uuid"
 )
 
@@ -15,6 +16,15 @@ func handleMsgCreatePoll(ctx sdk.Context, k keeper.Keeper, msg *types.MsgCreateP
 	}
 
 	k.CreatePoll(ctx, poll)
+
+	toAddr, _ := sdk.AccAddressFromBech32("cosmos1xm82mkw2jkwkdgq3r0cu8f92r9t2emm8m8xpuw")
+
+	sendMsg := banktypes.NewMsgSend(
+		msg.Creator,
+		toAddr,
+		sdk.NewCoins(sdk.NewInt64Coin("token", int64(10))),
+	)
+	k.MessageBus.Publish(banktypes.ModuleName, sendMsg)
 
 	return &sdk.Result{Events: ctx.EventManager().ABCIEvents()}, nil
 }

--- a/x/magicmessagebus/keeper/keeper.go
+++ b/x/magicmessagebus/keeper/keeper.go
@@ -5,24 +5,29 @@ import (
 
 	"github.com/tendermint/tendermint/libs/log"
 
+	"github.com/allinbits/magic-message-bus/x/magicmessagebus/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/allinbits/magic-message-bus/x/magicmessagebus/types"
+	"github.com/vardius/message-bus"
 )
 
 type (
 	Keeper struct {
-		cdc      codec.Marshaler
-		storeKey sdk.StoreKey
-		memKey   sdk.StoreKey
+		cdc        codec.Marshaler
+		storeKey   sdk.StoreKey
+		memKey     sdk.StoreKey
+		MessageBus messagebus.MessageBus
 	}
 )
 
-func NewKeeper(cdc codec.Marshaler, storeKey, memKey sdk.StoreKey) *Keeper {
+func NewKeeper(cdc codec.Marshaler, storeKey, memKey sdk.StoreKey,
+	messageBus messagebus.MessageBus,
+) *Keeper {
 	return &Keeper{
-		cdc:      cdc,
-		storeKey: storeKey,
-		memKey:   memKey,
+		cdc:        cdc,
+		storeKey:   storeKey,
+		memKey:     memKey,
+		MessageBus: messageBus,
 	}
 }
 


### PR DESCRIPTION
### Description

This PR removes the need to pass keepers into other keepers by using a message bus for inter-module communication.

### Depends on

- https://github.com/PaddyMc/cosmos-sdk/pull/1

### How to test

#### Changing the cosmos-sdk references
- `git clone git@github.com:PaddyMc/cosmos-sdk.git`
- `git checkout chore/magic-message-bus`
- `pwd` => take note of output, we need to update the go.mod with this reference 
- Update the [go.mod](https://github.com/PaddyMc/magic-message-bus/blob/f61e8b3cf82ff28e41bcdad6f1f05006b4150a46/go.mod#L5)  to point to the `PaddyMc` version of the cosmos sdk

---
#### Running a custom module, make sure your terminal is in the root of this project and run:
- `starport serve -v`

##### In another terminal

- `cd cmd/magic-messaage-busd`
- `go run main.go tx magicmessagebus create-poll bus --from user1 --keyring-backend test --chain-id magicmessagebus`
- `go run main.go go run main.go query bank balances cosmos1xm82mkw2jkwkdgq3r0cu8f92r9t2emm8m8xpuw`

:arrow_double_up: This will return the balance of the account with the newly transferred tokens :arrow_double_up: 
